### PR TITLE
Fix: getAllTags bug when there are more than 15 tags

### DIFF
--- a/packages/astro-ghostcms-brutalbyelian/src/routes/tag/[slug].astro
+++ b/packages/astro-ghostcms-brutalbyelian/src/routes/tag/[slug].astro
@@ -8,7 +8,7 @@ import { getAllPosts, getAllTags, getSettings, invariant } from "@matthiesenxyz/
 
 export async function getStaticPaths() {
   const posts = await getAllPosts();
-  const { tags } = await getAllTags();
+  const tags = await getAllTags();
   const settings = await getSettings();
 
   return tags.map((tag) => {

--- a/packages/astro-ghostcms-brutalbyelian/src/routes/tags.astro
+++ b/packages/astro-ghostcms-brutalbyelian/src/routes/tags.astro
@@ -2,7 +2,7 @@
 import Layout from '../layouts/Default.astro';
 import { getAllTags, getSettings, invariant } from "@matthiesenxyz/astro-ghostcms/api";
 import TagSummaryCard from '../components/generic/TagSummaryCard.astro';
-const { tags } = await getAllTags();
+const tags = await getAllTags();
 const settings = await getSettings();
 invariant(settings, 'Settings not found');
 const title = settings.title;
@@ -16,7 +16,7 @@ const description = settings.description;
   description={description}
 >
   <main class='bg-pink p-6'>
-    { 
+    {
       tags
         .filter((tag) => tag.slug && !tag.slug.startsWith("hash-"))
         .map((tag) => (

--- a/packages/astro-ghostcms-catppuccin/src/routes/tag/[slug].astro
+++ b/packages/astro-ghostcms-catppuccin/src/routes/tag/[slug].astro
@@ -7,7 +7,7 @@ import PostPreview from '../../components/PostPreview.astro';
 
 export async function getStaticPaths() {
   const posts = await getAllPosts();
-  const { tags } = await getAllTags();
+  const tags = await getAllTags();
   const settings = await getSettings();
 
   return tags.map((tag) => {
@@ -37,7 +37,7 @@ const description = `All of the articles we've posted and linked so far under th
 <Layout title={title} description={description} settings={settings}>
   <Container>
     <section class="post-card post-card-large">
-      
+
       <div class="post-card-content">
         <div class="post-card-content-link">
           <header class="post-card-header">

--- a/packages/astro-ghostcms-catppuccin/src/routes/tags.astro
+++ b/packages/astro-ghostcms-catppuccin/src/routes/tags.astro
@@ -6,7 +6,7 @@ import { getAllTags, getSettings, invariant } from "@matthiesenxyz/astro-ghostcm
 
 let title = "All Tags";
 let description = "All the tags used so far...";
-const { tags } = await getAllTags();
+const tags = await getAllTags();
 const settings = await getSettings();
 invariant(settings, 'Settings not found');
 

--- a/packages/astro-ghostcms-theme-default/src/routes/tag/[slug].astro
+++ b/packages/astro-ghostcms-theme-default/src/routes/tag/[slug].astro
@@ -1,13 +1,13 @@
 ---
-import type { InferGetStaticParamsType, InferGetStaticPropsType } from 'astro';
-import DefaultPageLayout from "../../layouts/default.astro";
-import PostPreview from "../../components/PostPreview.astro";
 import { getAllPosts, getAllTags, getSettings, invariant } from "@matthiesenxyz/astro-ghostcms/api";
+import type { InferGetStaticParamsType, InferGetStaticPropsType } from 'astro';
+import PostPreview from "../../components/PostPreview.astro";
+import DefaultPageLayout from "../../layouts/default.astro";
 import { getGhostImgPath } from "../../utils";
 
 export async function getStaticPaths() {
   const posts = await getAllPosts();
-  const { tags } = await getAllTags();
+  const tags = await getAllTags();
   const settings = await getSettings();
 
   return tags.map((tag) => {

--- a/packages/astro-ghostcms-theme-default/src/routes/tags.astro
+++ b/packages/astro-ghostcms-theme-default/src/routes/tags.astro
@@ -1,13 +1,13 @@
 ---
-import DefaultPageLayout from "../layouts/default.astro";
+import { getAllTags, getSettings, invariant } from "@matthiesenxyz/astro-ghostcms/api";
 import TagCard from "../components/TagCard.astro";
-import { getSettings, getAllTags, invariant } from "@matthiesenxyz/astro-ghostcms/api";
+import DefaultPageLayout from "../layouts/default.astro";
 
 
 let title = "All Tags";
 let description = "All the tags used so far...";
 
-const { tags } = await getAllTags();
+const tags = await getAllTags();
 const settings = await getSettings();
 invariant(settings, "Settings not found");
 ---

--- a/packages/astro-ghostcms/src/integrations/satoriog/routes/tag/[slug].png.ts
+++ b/packages/astro-ghostcms/src/integrations/satoriog/routes/tag/[slug].png.ts
@@ -16,7 +16,7 @@ import satoriOG from "../../satori";
 export const getStaticPaths: GetStaticPaths = async () => {
 	const result: GetStaticPathsItem[] = [];
 	const posts = await getAllPosts();
-	const { tags } = await getAllTags();
+	const tags = await getAllTags();
 	const settings = await getSettings();
 	invariant(settings, "Settings are required");
 

--- a/packages/create-astro-ghostcms/src/templates/starterkit/src/pages/tag/[slug].astro
+++ b/packages/create-astro-ghostcms/src/templates/starterkit/src/pages/tag/[slug].astro
@@ -1,13 +1,13 @@
 ---
-import type { InferGetStaticParamsType, InferGetStaticPropsType } from 'astro';
-import DefaultPageLayout from "../../layouts/default.astro";
-import PostPreview from "../../components/PostPreview.astro";
 import { getAllPosts, getAllTags, getSettings, invariant } from "@matthiesenxyz/astro-ghostcms/api";
+import type { InferGetStaticParamsType, InferGetStaticPropsType } from 'astro';
+import PostPreview from "../../components/PostPreview.astro";
+import DefaultPageLayout from "../../layouts/default.astro";
 import { getGhostImgPath } from "../../utils";
 
 export async function getStaticPaths() {
   const posts = await getAllPosts();
-  const { tags } = await getAllTags();
+  const tags = await getAllTags();
   const settings = await getSettings();
 
   return tags.map((tag) => {

--- a/packages/create-astro-ghostcms/src/templates/starterkit/src/pages/tags.astro
+++ b/packages/create-astro-ghostcms/src/templates/starterkit/src/pages/tags.astro
@@ -1,13 +1,13 @@
 ---
-import DefaultPageLayout from "../layouts/default.astro";
+import { getAllTags, getSettings, invariant } from "@matthiesenxyz/astro-ghostcms/api";
 import TagCard from "../components/TagCard.astro";
-import { getSettings, getAllTags, invariant } from "@matthiesenxyz/astro-ghostcms/api";
+import DefaultPageLayout from "../layouts/default.astro";
 
 
 let title = "All Tags";
 let description = "All the tags used so far...";
 
-const { tags } = await getAllTags();
+const tags = await getAllTags();
 const settings = await getSettings();
 invariant(settings, "Settings not found");
 ---


### PR DESCRIPTION
This commit fixes a bug in the getAllTags function that caused it to not retrieve all tags when there were more than 15 tags. This bug resulted in 404 errors on tag slug pages.

fix https://github.com/MatthiesenXYZ/astro-ghostcms/issues/99