### PR TITLE
FIX Update ghostAPI.ts to use environment URL instead of package URL when available

### DIFF
--- a/packages/astro-ghostcms/src/api/ghostAPI.ts
+++ b/packages/astro-ghostcms/src/api/ghostAPI.ts
@@ -16,7 +16,7 @@ const CONF_URL = config.ghostURL;
 
 // SETUP GHOST API
 const ghostApiKey = CONTENT_API_KEY || "";
-const ghostUrl = CONF_URL || CONTENT_API_URL || "";
+const ghostUrl = CONTENT_API_URL || CONF_URL || "";
 const version = "v5.0";
 const api = new TSGhostContentAPI(ghostUrl, ghostApiKey, version);
 


### PR DESCRIPTION
Fix setting of ghostURL to use user set URL instead of default

Currently script prioritizes CONF_URL which is a package default.

set CONTENT_API_URL to have priority to ensure user set URL has priority.